### PR TITLE
Revert to jQuery Version

### DIFF
--- a/addon/helpers/render-markdown.js
+++ b/addon/helpers/render-markdown.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import jquery from 'jquery';
 import markdownit from 'markdown-it';
 import markdownItAttrs from 'markdown-it-attrs';
 
@@ -12,32 +13,29 @@ const {
   },
 } = Ember;
 
-function parseHTML(str) {
-  let tmp = document.implementation.createHTMLDocument();
+function defuckifyHTML(domNodes) {
+  if (!domNodes) {
+    return '';
+  } else {
+    let container = jquery('<span>');
 
-  tmp.body.innerHTML = str;
+    jquery.each(domNodes, function(_, val) {
+      container.append(val);
+    });
 
-  return tmp.body.children;
+    return container.html();
+  }
 }
 
 function targetLinks(html) {
   let origin = window.location.origin;
-  let nodes = parseHTML(html);
-  let finishedHTML = '';
+  let nodes = jquery.parseHTML(html);
 
-  for (let i = 0; i < nodes.length; i++) {
-    let node = nodes.item(i);
-    let links = node.querySelectorAll(`a[href^='mailto'], a[href^='http']:not([href^='${origin}'])`);
+  jquery(`a[href^='mailto'], a[href^='http']:not([href^='${origin}'])`, nodes)
+    .attr('target', '_blank')
+    .attr('rel', 'noopener noreferrer');
 
-    links.forEach(function(node) {
-      node.setAttribute('target', '_blank');
-      node.setAttribute('rel', 'noopener noreferrer');
-    });
-
-    finishedHTML += node.outerHTML;
-  }
-
-  return finishedHTML;
+  return defuckifyHTML(nodes);
 }
 
 export function renderMarkdown([raw]) {

--- a/tests/integration/helpers/render-markdown-test.js
+++ b/tests/integration/helpers/render-markdown-test.js
@@ -17,7 +17,7 @@ test('renders markdown', function(assert) {
   let ret = find('*');
 
   assert.equal(
-    ret.innerHTML,
+    ret.innerHTML.trim(),
     '<h1>foo</h1>'
   );
 });
@@ -38,20 +38,26 @@ Be cool,
 
 J.`);
 
-  let expectedRet = `<h1>Hey guy</h1><p>How are you doing?</p><p>Hopefully all is well.</p><p>This is a list:</p><ul>
+  let expectedRet = `<h1>Hey guy</h1>
+<p>How are you doing?</p>
+<p>Hopefully all is well.</p>
+<p>This is a list:</p>
+<ul>
 <li>
 <p>Foo</p>
 </li>
 <li>
 <p><a href="http://example.com" target="_blank" rel="noopener noreferrer"><em>bar</em></a></p>
 </li>
-</ul><p>Be cool,</p><p>J.</p>`;
+</ul>
+<p>Be cool,</p>
+<p>J.</p>`;
 
   this.render(hbs`{{render-markdown raw}}`);
 
   let ret = find('*');
 
-  let innerHTML = ret.innerHTML;
+  let innerHTML = ret.innerHTML.trim();
 
   assert.equal(
     innerHTML,


### PR DESCRIPTION
This is a bit sad. We ran into some issues with iOS9. Basically the
result of `querySelectorAll` does not respond to `forEach` (thanks,
Apple!). Instead of fixing this and running it through a test gauntlet,
we'll just revert for now. We can fix this for real down the road.