### PR TITLE
Add ember-cli-htmlbars to Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-stew": "^1.5.0",
     "ember-cli-babel": "^6.6.0",
+    "ember-cli-htmlbars": "^2.0.1",
     "markdown-it": "^8.4.0",
     "markdown-it-attrs": "^1.1.0"
   },
@@ -34,7 +35,6 @@
     "ember-cli": "~3.1.2",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
-    "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.1.1",


### PR DESCRIPTION
Without this we cannot import `htmlSafe`