### PR TITLE
[SP-876] handle null doc for IE 11

### DIFF
--- a/addon/helpers/render-markdown.js
+++ b/addon/helpers/render-markdown.js
@@ -18,9 +18,8 @@ function targetLinks(html) {
     node.setAttribute('rel', 'noopener noreferrer');
   }
 
-  let newHTML = doc.body.innerHTML;
-
-  return newHTML;
+  // IE 11 returns NULL on empty string :/
+  return doc.body ? doc.body.innerHTML : '';
 }
 
 export function renderMarkdown([raw]) {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/DOMParser

turns out `DOMParser` returns `null` in IE11 if passed an empty string

this bombs badly for our users